### PR TITLE
Added componentDidMount for filling input field by default value

### DIFF
--- a/src/lib/MaskedInput.tsx
+++ b/src/lib/MaskedInput.tsx
@@ -39,6 +39,10 @@ export default class FormInputComponent extends Component<Props> {
     rules: []
   };
 
+  componentDidMount() {
+    this.setValue(this._getDisplayValue());
+  }
+
   componentWillReceiveProps(nextProps: Props) {
     if (!this.props.mask) return null;
     if (


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When opening a form with data, the fields remain empty until the first entry
Reproduction link:
https://codesandbox.io/s/reproduction-antd-mask-input-x2smi


* **What is the new behavior (if this is a feature change)?**
If there are default values on the form, they will appear after mounting
![image](https://user-images.githubusercontent.com/9379100/59771949-7d453680-92b3-11e9-8bae-1c166a34e87d.png)

