### PR TITLE
fix: TypeError: Cannot set property 'value' of null when creating snapshot

### DIFF
--- a/src/lib/MaskedInput.tsx
+++ b/src/lib/MaskedInput.tsx
@@ -58,7 +58,7 @@ export default class MaskedInput extends Component<MaskedInputProps> {
     } else if (this.props.mask !== nextProps.mask) {
       this.mask.setPattern(nextProps.mask, { value: this.mask.getRawValue() });
     }
-    
+
     if (this.props.value !== nextProps.value) {
       this.mask.setValue(nextProps.value);
       this.setInputValue(this._getDisplayValue());
@@ -243,7 +243,7 @@ export default class MaskedInput extends Component<MaskedInputProps> {
 
   _lastValue = null as any;
   setInputValue = (value: string) => {
-    if (!this._Input) return;
+    if (!this._Input || !this._Input.input) return;
     if (value === this._lastValue) return;
 
     this._lastValue = value;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugifx


* **What is the current behavior?** (You can also link to an open issue here)
```js
  TypeError: Cannot set property 'value' of null
```
when trying to use react-test-renderer


