### PR TITLE
Migrating from old lifecycles to new ones.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ test
 src/**.js
 .idea/*
 
+coverage.lcov
 coverage
 .nyc_output
 *.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "antd-mask-input",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Ant Design Mask Input",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -16,6 +16,12 @@
     "masked"
   ],
   "author": "@antoniopresto",
+  "contributors": [
+    {
+      "name": "Eduardo Amaral",
+      "url": "https://rolimans.dev"
+    }
+  ],
   "scripts": {
     "describe": "npm-scripts-info",
     "build": "run-s clean && run-p build:*",
@@ -24,7 +30,7 @@
     "fix": "run-s fix:*",
     "test": "run-s build test:*",
     "test:unit": "nyc --silent ava",
-    "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch\"",
+    "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch --verbose\"",
     "cov": "run-s build test:unit cov:html && opn coverage/index.html",
     "cov:html": "nyc report --reporter=html",
     "cov:send": "nyc report --reporter=lcov > coverage.lcov && codecov",

--- a/src/lib/MaskedInput.spec.tsx
+++ b/src/lib/MaskedInput.spec.tsx
@@ -112,7 +112,7 @@ test('should handle updating mask and value', t => {
   render({ mask: '11/11/1111', value: '25091989' });
   input = ReactDOM.findDOMNode(ref);
 
-  t.deepEqual(ref._Input.state.value, '25/09/1989');
+  t.deepEqual(ref.state._Input.state.value, '25/09/1989');
   t.deepEqual(input.value, '25/09/1989');
 });
 


### PR DESCRIPTION
Replaced componentWillUpdate and componentWillReceiveProps for getDerivedStateFromProps.

All propeties of the Component were placed inside it's state so they could be accessed inside the static getDerivedStateFromProps method.

Proposed version 0.1.15 .

* **What kind of change does this PR introduce?** 
Bug fix


* **What is the current behavior?** 
Warnings about the legacy lifecycles are emitted when the component is rendered.
fixes #16 